### PR TITLE
Update mcp2515.h

### DIFF
--- a/mcp2515.h
+++ b/mcp2515.h
@@ -417,6 +417,7 @@ class MCP2515
         } RXB[N_RXBUFFERS];
 
         uint8_t SPICS;
+        SPIClass *_spi;
 
     private:
 
@@ -434,7 +435,7 @@ class MCP2515
         void prepareId(uint8_t *buffer, const bool ext, const uint32_t id);
     
     public:
-        MCP2515(const uint8_t _CS);
+        MCP2515(const uint8_t _CS, SPIClass *spi);
         ERROR reset(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();


### PR DESCRIPTION
Передача объекта SPIClass в конструктор для совместимости с платами с несколькими SPI портами.